### PR TITLE
Set the default encoding to UTF8 for new databases

### DIFF
--- a/setup-database.sh
+++ b/setup-database.sh
@@ -23,7 +23,7 @@ if [[ ! "$(ls -A ${DATADIR})" ]]; then
   # Initialise db
   echo "Initializing Postgres Database at ${DATADIR}"
   #chown -R postgres $DATADIR
-  su - postgres -c "$INITDB ${DATADIR}"
+  su - postgres -c "$INITDB -E UTF8 ${DATADIR}"
 fi
 
 # test database existing


### PR DESCRIPTION
If this builds successfully on docker hub, we can merge this and then rebuild the docker images that depend on it, including insurance-requirements and data-env.

This should fix bugs we've seen where our python code is unable to read data that was originally UTF8 but is being stored in an SQL_ASCII encoded database, resulting in errors like "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2: ordinal not in range(128)"